### PR TITLE
Memory leaks fix

### DIFF
--- a/SpacerNET_Union/ActionRestore.cpp
+++ b/SpacerNET_Union/ActionRestore.cpp
@@ -116,6 +116,7 @@ namespace GOTHIC_ENGINE {
 			auto entry = list->data;
 			if (entry && entry->pVob == pVob)
 			{
+				delete entry;
 				pList.Remove(entry);
 				break;
 			}

--- a/SpacerNET_Union/CSettings.cpp
+++ b/SpacerNET_Union/CSettings.cpp
@@ -534,7 +534,7 @@ namespace GOTHIC_ENGINE {
 
 	CSettings::~CSettings()
 	{
-		list.Clear();
+		DeleteAndClearMap(list);
 	}
 
 }

--- a/SpacerNET_Union/GenerateVobsVisualsList.cpp
+++ b/SpacerNET_Union/GenerateVobsVisualsList.cpp
@@ -421,7 +421,8 @@ tr.warning{background-color:#e17a42}tr.error{background-color:red}.texture_word_
 
 		outfile << endFile;
 
-		searchVisualUniqList.Clear();
+		DeleteAndClearMap(searchVisualUniqList);
+
 
 		outfile.close();
 	}

--- a/SpacerNET_Union/Headers.h
+++ b/SpacerNET_Union/Headers.h
@@ -4,6 +4,7 @@
 // Automatically generated block
 
 #pragma region Includes
+#include "Utils.h"
 #include "Macros.h"
 #include "Enums.h"
 #include "TSTACKTYPE.h"

--- a/SpacerNET_Union/KeysManager.cpp
+++ b/SpacerNET_Union/KeysManager.cpp
@@ -260,7 +260,7 @@ namespace GOTHIC_ENGINE {
 
 	void KeysManager::ResetDefault()
 	{
-		keysMap.Clear();
+		DeleteAndClearMap(keysMap);
 
 		auto arr = defaultValues.GetArray();
 

--- a/SpacerNET_Union/MatFilter.cpp
+++ b/SpacerNET_Union/MatFilter.cpp
@@ -50,6 +50,8 @@ namespace GOTHIC_ENGINE {
 					{
 						matFilterList.RemoveOrderIndex(i);
 						cmd << "Remove filter: " << index << " name: " << entry->name << endl;
+						delete entry;
+						entry = nullptr;
 						break;
 					}
 

--- a/SpacerNET_Union/MatFilter_LoadSave.cpp
+++ b/SpacerNET_Union/MatFilter_LoadSave.cpp
@@ -383,7 +383,7 @@ namespace GOTHIC_ENGINE {
 		{
 			if (f->Open(false) == 0)
 			{
-				matFilterList.EmptyList();
+				matFilterList.DeleteListDatas();
 
 				spcCMatFilter* item = new spcCMatFilter;
 				item->id = 0;

--- a/SpacerNET_Union/Play.cpp
+++ b/SpacerNET_Union/Play.cpp
@@ -201,12 +201,13 @@ namespace GOTHIC_ENGINE {
 			parser->SetInstance("ITEM", NULL);
 
 			ogame->spawnman->ClearList();
-
+			
+			delete ogame->infoman;
 			ogame->infoman = zNEW(oCInfoManager)(parser);
 
 			oCLogManager::GetLogManager().Clear();
 
-
+			delete ogame->newsman;
 			ogame->newsman = zNEW(oCNewsManager());
 
 			if (zsound) zsound->StopAllSounds();

--- a/SpacerNET_Union/SpacerApp.h
+++ b/SpacerNET_Union/SpacerApp.h
@@ -34,8 +34,7 @@ namespace GOTHIC_ENGINE {
 
 		void ClearRespList()
 		{
-
-			respawnShowList.Clear();
+			DeleteAndClearMap(respawnShowList);
 		}
 
 

--- a/SpacerNET_Union/SpacerNET_Union.vcxproj
+++ b/SpacerNET_Union/SpacerNET_Union.vcxproj
@@ -1062,6 +1062,7 @@
       <SubType>
       </SubType>
     </ClInclude>
+    <ClInclude Include="Utils.h" />
     <ClInclude Include="zCObjPresetLib.h">
       <SubType>
       </SubType>

--- a/SpacerNET_Union/SpacerNET_Union.vcxproj.filters
+++ b/SpacerNET_Union/SpacerNET_Union.vcxproj.filters
@@ -3023,6 +3023,9 @@
     <ClInclude Include="Spacer_Hooks.cpp">
       <Filter>Plugin\Workspace\Plugin\Main\SpacerApp\Hooks</Filter>
     </ClInclude>
+    <ClInclude Include="Utils.h">
+      <Filter>Plugin\Workspace\Plugin\Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".build_settings.inl">

--- a/SpacerNET_Union/Utils.h
+++ b/SpacerNET_Union/Utils.h
@@ -1,0 +1,10 @@
+template<typename Key, typename Value>
+void DeleteAndClearMap(Common::Map<Key, Value*>& map)
+{
+	for (auto& pointer : map)
+	{
+		pointer.Delete();
+	}
+
+	map.Clear();
+}

--- a/SpacerNET_Union/VobManipulator.cpp
+++ b/SpacerNET_Union/VobManipulator.cpp
@@ -1083,8 +1083,6 @@ namespace GOTHIC_ENGINE {
 
 		void Clear()
 		{
-			ZeroMemory(&vobFoundStruct, sizeof vobFoundStruct);
-
 			itemsLoc.DeleteListDatas();
 
 			

--- a/SpacerNET_Union/VobManipulator.cpp
+++ b/SpacerNET_Union/VobManipulator.cpp
@@ -1005,6 +1005,11 @@ namespace GOTHIC_ENGINE {
 					{
 						pList.Insert(entry);
 					}
+					else
+					{
+						delete entry;
+						entry = nullptr;
+					}
 					
 				}
 			}

--- a/SpacerNET_Union/VobManipulator.cpp
+++ b/SpacerNET_Union/VobManipulator.cpp
@@ -963,7 +963,7 @@ namespace GOTHIC_ENGINE {
 
 			ogame->GetWorld()->SearchVobListByBaseClass(zCVob::classDef, vobs, 0);
 
-			pList.DeleteList();
+			pList.DeleteListDatas();
 
 			for (int i = 0; i < vobs.GetNum(); i++)
 			{

--- a/SpacerNET_Union/World.cpp
+++ b/SpacerNET_Union/World.cpp
@@ -836,6 +836,12 @@ namespace GOTHIC_ENGINE {
 			};
 
 		}
+
+		if (bbox)
+		{
+			delete bbox; 
+			bbox = nullptr;
+		}
 	}
 
 


### PR DESCRIPTION
I have found some memory leaks in the code and this PR fixes them.

The most common issue was not deleting pointers before clearing maps (Applies to these maps: KeyManager::keysMap, CSettings::list, SpacerApp::respawnShowList, searchVisualUniqList).
Additionally, I have resolved leaks associated with:
- Removing materials
- Light compilation
- Deleting ActionRestore on the remove of vob
- Play game mode