### PR TITLE
Fixed light editor showing dynamic light range

### DIFF
--- a/SpacerNET_Union/SpacerApp.cpp
+++ b/SpacerNET_Union/SpacerApp.cpp
@@ -2165,7 +2165,7 @@ namespace GOTHIC_ENGINE {
 			Stack_PushInt(1);
 		}
 
-		Stack_PushInt(lightData.range);
+		Stack_PushInt(lightData.rangeBackup);
 		Stack_PushInt(lightData.lightQuality);
 		Stack_PushBool(lightData.isStatic);
 


### PR DESCRIPTION
- Instead of showing the current light range, i've changed the code, so that it displays the initial light range.
- This change is needed when someone would like to restore the `dynamic light range` feature.