### PR TITLE
Added support for G1A and G2:

### DIFF
--- a/SpacerNET_Union/AB_NoGrass.cpp
+++ b/SpacerNET_Union/AB_NoGrass.cpp
@@ -43,7 +43,7 @@ namespace GOTHIC_ENGINE {
 					hiddenAmount += 1;
 					vobListGrass.Insert(pVob);
 				}
-				else if (hideBush && (name.contains("NW_NATURE_BUSH") || name.contains("NW_NATURE_FARN") || bushList.IsInList(name)))
+				else if (hideBush && (name.Contains("NW_NATURE_BUSH") || name.Contains("NW_NATURE_FARN") || bushList.IsInList(name)))
 				{
 					bariCenter += pVob->GetPositionWorld();
 					hiddenAmount += 1;
@@ -204,7 +204,7 @@ namespace GOTHIC_ENGINE {
 					{
 						zSTRING name = pVob->GetVisual()->GetVisualName().Upper();
 
-						if (name.contains("NW_NATURE_BUSH") || name.contains("NW_NATURE_FARN") || bushList.IsInList(name))
+						if (name.Contains("NW_NATURE_BUSH") || name.Contains("NW_NATURE_FARN") || bushList.IsInList(name))
 						{
 							entry->pListBush.InsertEnd(pVob);
 						}

--- a/SpacerNET_Union/API_Implementation.cpp
+++ b/SpacerNET_Union/API_Implementation.cpp
@@ -12,7 +12,6 @@ namespace GOTHIC_ENGINE {
 			return i;
 	}
 
-
 	void zCCamera::SetVob(zCVob* vob)
 	{
 		connectedVob = vob;
@@ -35,29 +34,51 @@ namespace GOTHIC_ENGINE {
 		t.n[VZ] = v[2][3];
 	};
 
+	int zMAT4::IsUpper3x3Orthonormal() const
+	{
+#if ENGINE == Engine_G1
+		XCALL(0x00505E40);
+#elif ENGINE == Engine_G1A
+		XCALL(0x00519D90);
+#elif ENGINE == Engine_G2
+		XCALL(0x00512C80);
+#elif ENGINE == Engine_G2A
+		XCALL(0x00515A50);
+#endif
+	}
 
 #if ENGINE == Engine_G1
-#define ISUPPER3X3ORTHONORMAL 0x00505E40
-#elif ENGINE == Engine_G1A
-#define ISUPPER3X3ORTHONORMAL 0x00519D90
-#elif ENGINE == Engine_G2
-#define ISUPPER3X3ORTHONORMAL 0x00512C80
-#elif ENGINE == Engine_G2A
-#define ISUPPER3X3ORTHONORMAL 0x00515A50
+	void zCPolygon::SetMaterial(zCMaterial* mat)
+	{
+		if (mat == material)
+			return;
+
+		if (material)
+			material->Release();
+
+		if (mat)
+			mat->AddRef();
+
+		material = mat;
+	}
 #endif
 
 
-	int zMAT4::IsUpper3x3Orthonormal() const
-	{
-		XCALL(ISUPPER3X3ORTHONORMAL);
-	}
-
-
-
+#if ENGINE != Engine_G1A
 	inline void zCCamera::BackProject(const int xscr, const int yscr, zVEC3& p) const {
 		p.n[VX] = zREAL(xscr - zFloat2Int(vpData.xcenter)) * zREAL(viewDistanceXInv) * p.n[VZ];
 		p.n[VY] = zREAL(zFloat2Int(vpData.ycenter) - yscr) * zREAL(viewDistanceYInv) * p.n[VZ];
 	};
+#endif
+
+#if ENGINE <= Engine_G1A
+	inline void zCCamera::ProjectClamp(zCVertexTransform* vertex, const float inv) const {
+		vertex->vertScrX = vpData.xcenter + ((vertex->vertCamSpace.n[VX] * viewDistanceX) * inv);
+		vertex->vertScrY = vpData.ycenter - ((vertex->vertCamSpace.n[VY] * viewDistanceY) * inv);
+		zClamp(vertex->vertScrX, vpData.xminFloat, vpData.xmaxFloat);
+		zClamp(vertex->vertScrY, vpData.yminFloat, vpData.ymaxFloat);
+	};
+#endif
 
 	struct zTMouseState {
 		int						xpos;				
@@ -72,19 +93,16 @@ namespace GOTHIC_ENGINE {
 	{
 
 
-#if ENGINE == Engine_G1
-		//FIXME_G1 Addr?
-		//int& leftMouseVal = *(int*)0x86CCB8;
-		//leftMouseVal = 0;
-		
+#if ENGINE == Engine_G1		
 		static zTMouseState& mouseState = *(zTMouseState*)0x0086CCAC;
-		mouseState.buttonPressedLeft = 0;
-
-#else
-		static zTMouseState& mouseState = *(zTMouseState*)0x8D165C;
-
-		mouseState.buttonPressedLeft = 0;
+#elif ENGINE == Engine_G1A
+		static zTMouseState& mouseState = *(zTMouseState*)0x008B27A8;
+#elif ENGINE == Engine_G2
+		static zTMouseState& mouseState = *(zTMouseState*)0x008C3004;
+#elif ENGINE == Engine_G2A
+		static zTMouseState& mouseState = *(zTMouseState*)0x008D165C;
 #endif
+		mouseState.buttonPressedLeft = 0;
 
 		
 		this->ClearKey(MOUSE_BUTTONLEFT);
@@ -100,20 +118,29 @@ namespace GOTHIC_ENGINE {
 		static bool* keyRepeatEnabled = (bool*)0x0086D0D8;
 		static zCArray<int>& keybuffer = *(zCArray<int>*)0x0086D2DC;
 
-		static int KEY_EVENT_TABLE_SIZE = 512 - 1;
-#else
+		constexpr int KEY_EVENT_TABLE_SIZE = (MAX_KEYS_AND_CODES + 1);
+#elif ENGINE == Engine_G1A
+		static bool* keyevent = (bool*)0x008B27C0;
+		static bool* keytoggle = (bool*)0x008B29D4;
+		static bool* keyRepeatEnabled = (bool*)0x008B2BE8;
+		static zCArray<int>& keybuffer = *(zCArray<int>*)0x008B2E00;
+
+		constexpr int KEY_EVENT_TABLE_SIZE = (MOUSE_XBUTTON5 + 1);
+#elif ENGINE == Engine_G2
+		static bool* keyevent = (bool*)0x008C3020;
+		static bool* keytoggle = (bool*)0x008C3260;
+		static bool* keyRepeatEnabled = (bool*)0x008C34B0;
+		static zCArray<int>& keybuffer = *(zCArray<int>*)0x008C36F0;
+
+		constexpr int KEY_EVENT_TABLE_SIZE = (JOY_BUTTON_32 + 1);
+#elif ENGINE == Engine_G2A
 		static bool* keyevent = (bool*)0x008D1678;
 		static bool* keytoggle = (bool*)0x008D18B8;
 		static bool* keyRepeatEnabled = (bool*)0x008D1B10;
 		static zCArray<int>& keybuffer = *(zCArray<int>*)0x008D1D50;
 
-		static int KEY_EVENT_TABLE_SIZE = (JOY_BUTTON_32 + 1);
-
-
-		//cmd << "SIze: " << KEY_EVENT_TABLE_SIZE << endl;
+		constexpr int KEY_EVENT_TABLE_SIZE = (JOY_BUTTON_32 + 1);
 #endif
-
-		
 
 		if (key < 0 || key > KEY_EVENT_TABLE_SIZE)
 			return;
@@ -145,5 +172,44 @@ namespace GOTHIC_ENGINE {
 		return result;
 	}
 
+#if ENGINE < Engine_G2A
+	zBOOL zTBBox3D::IsIntersecting(const zVEC3& rayOrigin, const zVEC3& rayDirection, zREAL& scaleMin, zREAL& scaleMax) const
+	{
+		zREAL minScale[3], maxScale[3];
+		zREAL absRayDirection[3];
 
+		absRayDirection[0] = abs(rayDirection[0]);
+		absRayDirection[1] = abs(rayDirection[1]);
+		absRayDirection[2] = abs(rayDirection[2]);
+
+		for (int i = 0; i < 3; i++)
+		{
+			if (absRayDirection[i] < zREAL(.0001F))
+			{
+				if (mins[i] > rayOrigin[i] || rayOrigin[i] > maxs[i])
+					return FALSE;
+
+				minScale[i] = zREAL_MIN;
+				maxScale[i] = zREAL_MAX;
+			}
+			else
+			{
+				minScale[i] = (mins[i] - rayOrigin[i]) / rayDirection[i];
+				maxScale[i] = (maxs[i] - rayOrigin[i]) / rayDirection[i];
+
+				if (maxScale[i] < minScale[i])
+				{
+					zREAL t = maxScale[i];
+					maxScale[i] = minScale[i];
+					minScale[i] = t;
+				}
+			}
+		}
+
+		scaleMin = max(minScale[0], max(minScale[1], minScale[2]));
+		scaleMax = min(maxScale[0], min(maxScale[1], maxScale[2]));
+
+		return scaleMin <= scaleMax;
+	}
+#endif
 }

--- a/SpacerNET_Union/ActionRestore.cpp
+++ b/SpacerNET_Union/ActionRestore.cpp
@@ -46,7 +46,7 @@ namespace GOTHIC_ENGINE {
 				pVob->SetPositionWorld(pVob->GetPositionWorld());
 				
 
-#if ENGINE >= Engine_G2
+#if ENGINE == Engine_G2A
 				pVob->EndMovement(FALSE);
 #else
 				pVob->EndMovement();

--- a/SpacerNET_Union/BboxDecalArea.cpp
+++ b/SpacerNET_Union/BboxDecalArea.cpp
@@ -143,7 +143,7 @@ namespace GOTHIC_ENGINE {
 			ogame->GetWorld()->AddVob(side);
 			side->SetCollDet(FALSE);
 			side->ignoredByTraceRay = true;
-#if ENGINE != Engine_G1
+#if ENGINE >= Engine_G2
 			side->m_fVobFarClipZScale = 2.0f;
 #endif
 			sides[i] = side;

--- a/SpacerNET_Union/BboxMovement.cpp
+++ b/SpacerNET_Union/BboxMovement.cpp
@@ -336,7 +336,7 @@ namespace GOTHIC_ENGINE {
 				pickedVob->BeginMovement();
 				pickedVob->SetPositionWorld(pickedVob->GetPositionWorld());
 
-#if ENGINE >= Engine_G2
+#if ENGINE >= Engine_G2A
 				pickedVob->EndMovement(FALSE);
 #else
 				pickedVob->EndMovement();

--- a/SpacerNET_Union/CSettings.cpp
+++ b/SpacerNET_Union/CSettings.cpp
@@ -152,8 +152,8 @@ namespace GOTHIC_ENGINE {
 
 			ogame->GetWorld()->showWaynet = GetIntVal("showWaynet");
 
-			zCVobLight::renderLightVisuals = GetIntVal("showHelpVobs");	
-			zCVob::SetShowHelperVisuals(zCVobLight::renderLightVisuals); 
+			zCVobLight::renderLightVisuals = GetIntVal("showHelpVobs");
+			zCVob::s_showHelperVisuals = zCVobLight::renderLightVisuals;
 
 			ogame->GetWorld()->bspTree.drawVobBBox3D = GetIntVal("drawBBoxGlobal");	
 

--- a/SpacerNET_Union/CameraManager.cpp
+++ b/SpacerNET_Union/CameraManager.cpp
@@ -257,7 +257,7 @@ namespace GOTHIC_ENGINE {
 			cur_cam->SetShowVisual(FALSE);
 
 			hideHelpVisualsTemp = zCVob::s_showHelperVisuals;
-			zCVob::SetShowHelperVisuals(FALSE);
+			zCVob::s_showHelperVisuals = FALSE;
 		}
 
 
@@ -320,12 +320,9 @@ namespace GOTHIC_ENGINE {
 
 		cameraRun = false;
 
-		if (hideVisualWhileActive)
+		if (hideVisualWhileActive && hideHelpVisualsTemp)
 		{
-			if (hideHelpVisualsTemp)
-			{
-				zCVob::SetShowHelperVisuals(TRUE);
-			}
+			zCVob::s_showHelperVisuals = TRUE;
 		}
 
 		theApp.SetSelectedVob(cur_cam, "CamStop");

--- a/SpacerNET_Union/CreateVobs.cpp
+++ b/SpacerNET_Union/CreateVobs.cpp
@@ -364,7 +364,7 @@ namespace GOTHIC_ENGINE {
 					vobSound->SetSound(vobName);
 					vobSound->soundRadius = 1500;
 					vobSound->soundVolume = 100;
-#if ENGINE == Engine_G2A
+#if ENGINE >= Engine_G2
 					vobSound->m_zBias = 0;
 #endif
 					vobSound->soundVolType = zCVobSound::zTSoundVolType::SV_SPHERE;
@@ -851,12 +851,9 @@ namespace GOTHIC_ENGINE {
 		oCItem* isItem = dynamic_cast<oCItem*>(pVob);
 	
 		// remove oCVisualFX from the item list
-#if ENGINE > Engine_G1
+#if ENGINE == Engine_G2A
 		if (isItem && isItem->effectVob)
-		{
 			theApp.OnRemoveVob(isItem->effectVob);
-			
-		}
 #endif
 		itemsLocator.RemoveByItem(pVob);
 		theApp.restorator.RemoveByVob(pVob);

--- a/SpacerNET_Union/Enums.h
+++ b/SpacerNET_Union/Enums.h
@@ -207,12 +207,5 @@ namespace GOTHIC_ENGINE {
 
 	enum TMatLibFlag { NullLib = 0 };
 
+	DllExport zTWE_ControllerEvents ControllerEvents;
 }
-
-#if ENGINE == Engine_G1
-DllExport Gothic_I_Classic::zTWE_ControllerEvents ControllerEvents;
-#else
-DllExport Gothic_II_Addon::zTWE_ControllerEvents ControllerEvents;
-#endif
-
-

--- a/SpacerNET_Union/ErrorReport_Materials.cpp
+++ b/SpacerNET_Union/ErrorReport_Materials.cpp
@@ -89,7 +89,7 @@ namespace GOTHIC_ENGINE {
 						}
 					}
 
-					if (mat->GetObjectName().contains(".0"))
+					if (mat->GetObjectName().Contains(".0"))
 					{
 						if (!mats.IsInList(mat))
 						{
@@ -108,7 +108,7 @@ namespace GOTHIC_ENGINE {
 						}
 					}
 
-					if (mat->texture->GetObjectName().contains(".TGA.TGA") || mat->texture->GetObjectName().contains(".TGA.0"))
+					if (mat->texture->GetObjectName().Contains(".TGA.TGA") || mat->texture->GetObjectName().Contains(".TGA.0"))
 					{
 						mats.InsertEnd(mat);
 

--- a/SpacerNET_Union/ErrorReport_Vobs.cpp
+++ b/SpacerNET_Union/ErrorReport_Vobs.cpp
@@ -473,7 +473,7 @@ namespace GOTHIC_ENGINE {
 					}
 				}
 
-				if (vob->GetVobName().contains(' ') && !vob->GetVobName().contains("SPELLFX"))
+				if (vob->GetVobName().Contains(' ') && !vob->GetVobName().Contains("SPELLFX"))
 				{
 					auto entry = new ErrorReportEntry();
 

--- a/SpacerNET_Union/Export_Union_DLL.cpp
+++ b/SpacerNET_Union/Export_Union_DLL.cpp
@@ -80,44 +80,20 @@ namespace GOTHIC_ENGINE {
 			if (!func)
 				return;
 
-
-#if ENGINE == Engine_G1
 			switch (evt)
 			{
-			case Gothic_I_Classic::SPC_EVT_OnCreateVob:
+			case GOTHIC_ENGINE::SPC_EVT_OnCreateVob:
 				arr_OnCreateVob_RegFuncs.Insert(func);
 				break;
-			case Gothic_I_Classic::SPC_EVT_OnDeleteVob:
+			case GOTHIC_ENGINE::SPC_EVT_OnDeleteVob:
 				arr_OnDeleteVob_RegFuncs.Insert(func);
 				break;
-			case Gothic_I_Classic::SPC_EVT_OnApplyDataToVob:
+			case GOTHIC_ENGINE::SPC_EVT_OnApplyDataToVob:
 				arr_OnApplyDataToVob_RegFuncs.Insert(func);
 				break;
-			case Gothic_I_Classic::SPC_EVT_OnSelectVob:
+			case GOTHIC_ENGINE::SPC_EVT_OnSelectVob:
 				arr_OnSelectVob_RegFuncs.Insert(func);
-				break;
-			default:
-				break;
-#else
-			switch (evt)
-			{
-			case Gothic_II_Addon::SPC_EVT_OnCreateVob:
-				arr_OnCreateVob_RegFuncs.Insert(func);
-				break;
-			case Gothic_II_Addon::SPC_EVT_OnDeleteVob:
-				arr_OnDeleteVob_RegFuncs.Insert(func);
-				break;
-			case Gothic_II_Addon::SPC_EVT_OnApplyDataToVob:
-				arr_OnApplyDataToVob_RegFuncs.Insert(func);
-				break;
-			case Gothic_II_Addon::SPC_EVT_OnSelectVob:
-				arr_OnSelectVob_RegFuncs.Insert(func);
-				break;
-			default:
-				break;
-#endif
-
-			
+				break;			
 			}
 		}
 

--- a/SpacerNET_Union/GrassPlacer.cpp
+++ b/SpacerNET_Union/GrassPlacer.cpp
@@ -316,14 +316,7 @@ namespace GOTHIC_ENGINE {
 
 
 #if ENGINE >= Engine_G2
-							if (isItem)
-							{
-								newVob->m_fVobFarClipZScale = 1;
-							}
-							else
-							{
-								newVob->m_fVobFarClipZScale = grassToolVobFarClipZScaleValue;
-							}
+							newVob->m_fVobFarClipZScale = isItem ? 1 : grassToolVobFarClipZScaleValue;
 #endif
 
 							if (!isItem)

--- a/SpacerNET_Union/Load3DS_Fast.cpp
+++ b/SpacerNET_Union/Load3DS_Fast.cpp
@@ -21,7 +21,7 @@ namespace GOTHIC_ENGINE {
 
 
 		dontCreateOBBOXOnLocationLoad = theApp.options.GetIntVal("bFastLoad3DSLocation") && (theApp.isMergingMeshNow || theApp.isLoadingMeshNow);
-		
+
 
 		if (dontCreateOBBOXOnLocationLoad)
 		{
@@ -32,7 +32,7 @@ namespace GOTHIC_ENGINE {
 				cmd << " (--- Skip OBBOX)";
 			}
 		}
-		
+
 
 		if (debugInfo) cmd << endl;
 
@@ -41,44 +41,10 @@ namespace GOTHIC_ENGINE {
 		dontCreateOBBOXOnLocationLoad = false;
 	}
 
-#if ENGINE == Engine_G2A
-
-	HOOK ivk_zCMesh_CalcBBox3D AS(&zCMesh::CalcBBox3D, &zCMesh::CalcBBox3D_Union);
-	void zCMesh::CalcBBox3D_Union(const zBOOL fastApprox) 
-	{
-		ArraysToLists();
-		UnshareFeatures();
-
-		// if dontCreateOBBOXOnLocationLoad => use usual AABB for fast loading a location
-		if (fastApprox || dontCreateOBBOXOnLocationLoad)
-		{
-			bbox3D.Init();
-			for (int vertCtr = 0; vertCtr < numVert; vertCtr++) {
-				zCVertex* vert = vertList[vertCtr];
-				for (int j = 0; j < 3; j++) {
-					bbox3D.mins[j] = zMin(bbox3D.mins[j], vert->position.n[j]);
-					bbox3D.maxs[j] = zMax(bbox3D.maxs[j], vert->position.n[j]);
-				};
-			};
-		}
-		else {
-			obbox3D.BuildOBBTree(this, 3);
-			bbox3D = obbox3D.GetBBox3D();
-		};
-		//
-		if ((numVert == 0) || (numPoly == 0)) {
-			zREAL D = 0.1F;
-			bbox3D.mins = -zVEC3(D, D, D);
-			bbox3D.maxs = zVEC3(D, D, D);
-		};
-	};
-#endif
-
-#if ENGINE == Engine_G1
 	HOOK ivk_zCMesh_CalcBBox3D AS(&zCMesh::CalcBBox3D, &zCMesh::CalcBBox3D_Union);
 	void zCMesh::CalcBBox3D_Union(const zBOOL bGreat)
 	{
-
+		ArraysToLists();
 		UnshareFeatures();
 		if (bGreat || dontCreateOBBOXOnLocationLoad)
 		{
@@ -91,13 +57,12 @@ namespace GOTHIC_ENGINE {
 			obbox3D.BuildOBBTree(this, 3);
 			bbox3D = obbox3D.GetBBox3D();
 		}
-		if (numVert && numPoly)
-			return;
 
-		zREAL D = 0.1F;
-		bbox3D.mins = -zVEC3(D, D, D);
-		bbox3D.maxs = zVEC3(D, D, D);
+		if ((numVert == 0) || (numPoly == 0))
+		{
+			zREAL D = 0.1F;
+			bbox3D.mins = -zVEC3(D, D, D);
+			bbox3D.maxs = zVEC3(D, D, D);
+		};
 	};
-
-#endif
 }

--- a/SpacerNET_Union/MatFilter.cpp
+++ b/SpacerNET_Union/MatFilter.cpp
@@ -79,7 +79,7 @@ namespace GOTHIC_ENGINE {
 		{
 			mat = dynamic_cast<zCMaterial*>(classDef->objectList[i]);
 
-			if (mat && (mat->GetName().StartWith(matName) || mat->GetName().contains(matName) || mat->GetName() == matName))
+			if (mat && (mat->GetName().StartWith(matName) || mat->GetName().Contains(matName) || mat->GetName() == matName))
 			{
 				pList.Insert(mat);
 			}

--- a/SpacerNET_Union/MatFilter_Render.cpp
+++ b/SpacerNET_Union/MatFilter_Render.cpp
@@ -177,7 +177,7 @@ namespace GOTHIC_ENGINE {
 
 		int result = 0;
 
-		zCTextureConvert* texConv = zrenderer->CreateTextureConvert();
+		zCTexConGeneric* texConv = reinterpret_cast<zCTexConGeneric*>(zrenderer->CreateTextureConvert());
 
 		// защита указателя
 		if (!texConv)

--- a/SpacerNET_Union/MultiSelect.cpp
+++ b/SpacerNET_Union/MultiSelect.cpp
@@ -118,7 +118,7 @@ namespace GOTHIC_ENGINE {
 
 					if (!ignoreCollisions) {
 
-#if ENGINE >= Engine_G2
+#if ENGINE >= Engine_G2A
 						int flags = zTRACERAY_STAT_POLY | zTRACERAY_VOB_IGNORE | zTRACERAY_VOB_IGNORE_PROJECTILES;
 #else
 						int flags = zTRACERAY_STAT_POLY | zTRACERAY_VOB_IGNORE;
@@ -159,7 +159,7 @@ namespace GOTHIC_ENGINE {
 					zVEC3 direction = vobPosition - cameraPosition;
 
 					if (!ignoreCollisions) {
-#if ENGINE >= Engine_G2
+#if ENGINE >= Engine_G2A
 						int flags = zTRACERAY_STAT_POLY | zTRACERAY_VOB_IGNORE | zTRACERAY_VOB_IGNORE_PROJECTILES;
 #else
 						int flags = zTRACERAY_STAT_POLY | zTRACERAY_VOB_IGNORE;

--- a/SpacerNET_Union/PFX_Editor.cpp
+++ b/SpacerNET_Union/PFX_Editor.cpp
@@ -4,29 +4,6 @@
 namespace GOTHIC_ENGINE {
 	// Add your code here . . .
 
-	typedef zCParticleEmitter* (*fptr)(class zSTRING const&);
-
-
-#if ENGINE == Engine_G1
-	zCArraySort<zCParticleEmitter*>& s_emitterPresetList = *(zCArraySort<zCParticleEmitter*>*)0x00873FA0;
-	oCParticleControl*& pfxcGlobal = *(oCParticleControl**)0x008DA6C0;
-
-	zCParser*& visualParser = *(zCParser**)0x00869E6C;
-	zCParser*& s_pfxParser = *(zCParser**)0x00874380;
-	fptr SearchParticleEmitter = (fptr)0x0058DEC0;
-#else
-	zCArraySort<zCParticleEmitter*>& s_emitterPresetList = *(zCArraySort<zCParticleEmitter*>*)0x008D8E0C;
-	oCParticleControl*& pfxcGlobal = *(oCParticleControl**)0x00AB088C;
-
-
-	zCParser*& visualParser = *(zCParser**)0x008CE6EC;
-	zCParser*& s_pfxParser = *(zCParser**)0x008D9234;
-	fptr SearchParticleEmitter = (fptr)0x005ADDE0;
-#endif
-
-
-
-
 	zCParticleFX* m_pPfx = NULL;
 	int instanceFieldSize = 0;
 	zCVob* pfxEditorVob = NULL;
@@ -43,7 +20,7 @@ namespace GOTHIC_ENGINE {
 		{
 			m_pPfx->StopEmitterOutput();
 
-			m_pPfx->SetAndStartEmitter(SearchParticleEmitter(currentPFXName.Upper()), FALSE);
+			m_pPfx->SetAndStartEmitter(zCParticleFX::SearchParticleEmitter(currentPFXName.Upper()), FALSE);
 			m_pPfx->dontKillPFXWhenDone = true;
 		}
 	}
@@ -87,7 +64,7 @@ namespace GOTHIC_ENGINE {
 	{
 		return;
 
-#if ENGINE > Engine_G1
+#if ENGINE >= Engine_G2A
 
 		if (m_pPfx && pfxEditorVob)
 		{
@@ -168,7 +145,7 @@ namespace GOTHIC_ENGINE {
 			//fixes the code in Invk_zCVobArchive. WTF?! 
 			if (theApp.GetSelectedVob() == pfxEditorVob)
 			{
-#if ENGINE > Engine_G1
+#if ENGINE >= Engine_G2
 				m_pPfx->m_bVisualNeverDies = FALSE;
 #endif
 			}
@@ -185,7 +162,7 @@ namespace GOTHIC_ENGINE {
 
 	void SpacerApp::GetAllPfx()
 	{
-		int size = s_emitterPresetList.GetNumInList();
+		int size = zCParticleFX::s_emitterPresetList.GetNumInList();
 
 		auto addPFX = (callVoidFunc)GetProcAddress(this->module, "AddPfxInstancemName");
 
@@ -193,7 +170,7 @@ namespace GOTHIC_ENGINE {
 
 		for (int i = 0; i < size; i++)
 		{
-			Stack_PushString(s_emitterPresetList.GetSafe(i)->particleFXName);
+			Stack_PushString(zCParticleFX::s_emitterPresetList.GetSafe(i)->particleFXName);
 			addPFX();
 		}
 	}
@@ -210,7 +187,7 @@ namespace GOTHIC_ENGINE {
 			return;
 		}
 
-		zCPar_Symbol* ps = s_pfxParser->GetSymbol(s_pfxParser->GetIndex(name));
+		zCPar_Symbol* ps = zCParticleFX::s_pfxParser->GetSymbol(zCParticleFX::s_pfxParser->GetIndex(name));
 
 		if (!ps)
 		{
@@ -218,13 +195,13 @@ namespace GOTHIC_ENGINE {
 			return;
 		}
 
-		int index = s_pfxParser->GetIndex(name);
+		int index = zCParticleFX::s_pfxParser->GetIndex(name);
 
-		int baseClassIndex = s_pfxParser->GetBaseClass(index);
-		int indClass = s_pfxParser->GetIndex(name);
+		int baseClassIndex = zCParticleFX::s_pfxParser->GetBaseClass(index);
+		int indClass = zCParticleFX::s_pfxParser->GetIndex(name);
 
-		zCPar_Symbol* base = s_pfxParser->GetSymbol(baseClassIndex);
-		zCPar_Symbol* pfx = s_pfxParser->GetSymbol(indClass);
+		zCPar_Symbol* base = zCParticleFX::s_pfxParser->GetSymbol(baseClassIndex);
+		zCPar_Symbol* pfx = zCParticleFX::s_pfxParser->GetSymbol(indClass);
 
 		void* addr = m_pPfx->emitter;
 		int type = 0;
@@ -249,7 +226,7 @@ namespace GOTHIC_ENGINE {
 		for (int i = 0; i < instanceFieldSize; i++)
 		{
 			// take the following base->f.tNumber characters, they are the instance fields
-			zCPar_Symbol* param = s_pfxParser->GetSymbol(baseClassIndex + i + 1);
+			zCPar_Symbol* param = zCParticleFX::s_pfxParser->GetSymbol(baseClassIndex + i + 1);
 
 			if (!param)
 			{
@@ -328,11 +305,11 @@ namespace GOTHIC_ENGINE {
 		}
 
 	
-		m_pPfx->SetAndStartEmitter(SearchParticleEmitter(name), FALSE);
+		m_pPfx->SetAndStartEmitter(zCParticleFX::SearchParticleEmitter(name), FALSE);
 
 
 
-		zCPar_Symbol* ps = s_pfxParser->GetSymbol(s_pfxParser->GetIndex(name));
+		zCPar_Symbol* ps = zCParticleFX::s_pfxParser->GetSymbol(zCParticleFX::s_pfxParser->GetIndex(name));
 		currentPFXName = name;
 
 		if (!ps)
@@ -343,13 +320,13 @@ namespace GOTHIC_ENGINE {
 
 
 
-		int index = s_pfxParser->GetIndex(name);
+		int index = zCParticleFX::s_pfxParser->GetIndex(name);
 
-		int baseClassIndex = s_pfxParser->GetBaseClass(index);
-		int indClass = s_pfxParser->GetIndex(name);
+		int baseClassIndex = zCParticleFX::s_pfxParser->GetBaseClass(index);
+		int indClass = zCParticleFX::s_pfxParser->GetIndex(name);
 
-		zCPar_Symbol* base = s_pfxParser->GetSymbol(baseClassIndex);
-		zCPar_Symbol* pfx = s_pfxParser->GetSymbol(indClass);
+		zCPar_Symbol* base = zCParticleFX::s_pfxParser->GetSymbol(baseClassIndex);
+		zCPar_Symbol* pfx = zCParticleFX::s_pfxParser->GetSymbol(indClass);
 
 		void* addr = m_pPfx->emitter;
 		int type = 0;
@@ -369,7 +346,7 @@ namespace GOTHIC_ENGINE {
 		for (int i = 0; i < instanceFieldSize; i++)
 		{
 
-			zCPar_Symbol* param = s_pfxParser->GetSymbol(baseClassIndex + i + 1);
+			zCPar_Symbol* param = zCParticleFX::s_pfxParser->GetSymbol(baseClassIndex + i + 1);
 
 			if (!param)
 			{

--- a/SpacerNET_Union/Search.cpp
+++ b/SpacerNET_Union/Search.cpp
@@ -447,7 +447,7 @@ namespace GOTHIC_ENGINE {
 					{
 						if (auto pCont = pVob->CastTo<oCMobContainer>())
 						{
-							if (pCont && pCont->contains.Upper().contains(itemNameSearch))
+							if (pCont && pCont->contains.Upper().Contains(itemNameSearch))
 							{
 								resultFound.Insert(pVob);
 

--- a/SpacerNET_Union/Sources.h
+++ b/SpacerNET_Union/Sources.h
@@ -3,13 +3,13 @@
 
 // Automatically generated block
 #pragma region Includes
+#include "Utils.cpp"
 #include "API_Implementation.cpp"
 #include "Interchange.cpp"
 #include "MyPrint.cpp"
 #include "Spacer_Init.cpp"
 #include "CSettings.cpp"
 #include "KeysManager.cpp"
-#include "Utils.cpp"
 #include "PFXManager.cpp"
 #include "Vob.cpp"
 #include "Lists.cpp"

--- a/SpacerNET_Union/SpacerApp.cpp
+++ b/SpacerNET_Union/SpacerApp.cpp
@@ -70,6 +70,7 @@ namespace GOTHIC_ENGINE {
 		this->cameraMoveWithVobActive = false;
 		this->wasCopiedPressed = false;
 		this->showVobVisualInfo = false;
+		this->holdTime = false;
 
 		this->rotMod = zMH_VIEW;
 
@@ -337,13 +338,6 @@ namespace GOTHIC_ENGINE {
 
 	void SpacerApp::SetHoldTime(int enabled)
 	{
-		//FIXME_G1 corrent address?
-#if ENGINE == Engine_G1
-		int& holdTime = *(int*)0x8DA6C0;
-#else
-		int& holdTime = *(int*)0xAB0888;
-#endif
-		
 		holdTime = enabled;
 	}
 
@@ -1089,7 +1083,7 @@ namespace GOTHIC_ENGINE {
 		int	traceFlags = zTRACERAY_STAT_POLY |
 			zTRACERAY_POLY_TEST_WATER;
 
-		if (zCVob::GetShowHelperVisuals())
+		if (zCVob::s_showHelperVisuals)
 			traceFlags |= zTRACERAY_VOB_TEST_HELPER_VISUALS;
 
 		zBOOL hit = wld->TraceRayNearestHit(ray00, ray, (zCVob*)0, traceFlags);
@@ -1216,12 +1210,6 @@ namespace GOTHIC_ENGINE {
 	{
 		//cmd << start.ToString() << " ; " << ray.ToString() << endl;
 
-		//FIXME_G1
-#if ENGINE == Engine_G1
-		print.PrintRed("NO G1 SUPPORT!");
-		return;
-
-#else
 		zCVob* pFoundVob = NULL;
 
 		zTBBox3D box;
@@ -1301,7 +1289,6 @@ namespace GOTHIC_ENGINE {
 
 		ogame->GetWorld()->traceRayReport.foundVob = pFoundVob;
 		ogame->GetWorld()->traceRayReport.foundHit = TRUE;
-#endif
 	}
 
 	void SpacerApp::PickVobFilter()
@@ -1332,7 +1319,7 @@ namespace GOTHIC_ENGINE {
 		world->traceRayIgnoreVobFlag = TRUE;
 		int	traceFlags = zTRACERAY_STAT_POLY | zTRACERAY_POLY_TEST_WATER;
 
-		if (zCVob::GetShowHelperVisuals())
+		if (zCVob::s_showHelperVisuals)
 			traceFlags |= zTRACERAY_VOB_TEST_HELPER_VISUALS;
 
 		//const 
@@ -1674,7 +1661,7 @@ namespace GOTHIC_ENGINE {
 		int	traceFlags = zTRACERAY_STAT_POLY |
 			zTRACERAY_POLY_TEST_WATER;
 
-		if (zCVob::GetShowHelperVisuals())
+		if (zCVob::s_showHelperVisuals)
 			traceFlags |= zTRACERAY_VOB_TEST_HELPER_VISUALS;
 
 		if (ctrlUsed)

--- a/SpacerNET_Union/SpacerApp.h
+++ b/SpacerNET_Union/SpacerApp.h
@@ -124,6 +124,7 @@ namespace GOTHIC_ENGINE {
 			bool dynLightCompile;
 			bool wasCopiedPressed;
 			bool showVobVisualInfo;
+			bool holdTime;
 
 			bool levelReady;
 			bool treeIsReady;

--- a/SpacerNET_Union/SpacerNET_Union.vcxproj
+++ b/SpacerNET_Union/SpacerNET_Union.vcxproj
@@ -374,7 +374,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='G1 Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)\G1\Bin\</OutDir>
+    <OutDir>$(SolutionDir)Bin\</OutDir>
     <IncludePath>$(ProjectDir)\;$(ProjectDir)\vdfs\;$(ProjectDir)\ZenGin\Gothic_UserAPI\;$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Include\;$(ALLUSERSPROFILE)\Union\SDK\DirectX7\include\;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)vdfs\;$(ALLUSERSPROFILE)\Union\SDK\Union\v1.0l\Lib\;$(ALLUSERSPROFILE)\Union\SDK\DirectX7\Lib\;$(LibraryPath)</LibraryPath>
     <TargetName>SpacerUnionNet</TargetName>

--- a/SpacerNET_Union/Spacer_Init.cpp
+++ b/SpacerNET_Union/Spacer_Init.cpp
@@ -34,9 +34,6 @@ namespace GOTHIC_ENGINE {
 		//cmd << foundExecutable << endl;
 
 #if ENGINE == Engine_G1
-
-		
-
 		if (foundExecutable != GOTHIC1_EXECUTABLE)
 		{
 			MessageBox(0, "Bad Gothic 1 EXE version! Use only 1.08k (mod)!", 0, 0);
@@ -44,7 +41,6 @@ namespace GOTHIC_ENGINE {
 		}
 
 #elif ENGINE == Engine_G2A
-
 		if (foundExecutable != GOTHIC2A_EXECUTABLE)
 		{
 			MessageBox(0, "Bad Gothic 2 NR EXE version! Use only 2.6.0.0 version!", 0, 0);
@@ -99,7 +95,7 @@ namespace GOTHIC_ENGINE {
 		/*
 		if (!zoptions->ReadBool("VIDEO", "zStartupWindowed", FALSE))
 		{
-			MessageBox(0, "Спейсер нужно запускать в оконном режиме! zStartupWindowed=1 в gothic.ini\nYou must launch SPACER_NET in a window mode! Set zStartupWindowed=1 in gothic.ini", 0, 0);
+			MessageBox(0, "ЕѓДЏДєГ©Е„ДєД‘ Г­ГіД‡Г­Г® Г§Е•ДЏГіЕ„Д™Е•Е€Гј Гў Г®Д™Г®Г­Г­Г®Д› Д‘ДєД‡ДЌД›Дє! zStartupWindowed=1 Гў gothic.ini\nYou must launch SPACER_NET in a window mode! Set zStartupWindowed=1 in gothic.ini", 0, 0);
 			exit(0);
 		}
 		*/
@@ -168,12 +164,15 @@ namespace GOTHIC_ENGINE {
 
 		//presetsLib.Load();
 
+		// kill gLogStatistics
 #if ENGINE == Engine_G1
-		// kill gLogStatistics
-		* (int*)0x0085EB00 = 0;
-#else
-		// kill gLogStatistics
-		* (int*)0x008C2B50 = 0;
+		*(bool*)0x0085EB00 = false;
+#elif ENGINE == Engine_G1A
+		*(bool*)0x008A3454 = false;
+#elif ENGINE == Engine_G2
+		*(bool*)0x008B4590 = false;
+#elif ENGINE == Engine_G2A
+		*(bool*)0x008C2B50 = false;
 #endif
 
 		showRespawnOnVobsRadius = options.GetIntVal("showSpawnListRadius");

--- a/SpacerNET_Union/Spacer_Loop.cpp
+++ b/SpacerNET_Union/Spacer_Loop.cpp
@@ -1061,14 +1061,14 @@ namespace GOTHIC_ENGINE {
 
 			print.PrintRed(ToStr GetLang("UNION_LIGHT_RAD_ZERO"));
 
-#if ENGINE > Engine_G1
+#if ENGINE >= Engine_G2
 			if (zCSkyControler::GetActiveSkyControler())
 			{
 				zCSkyControler::GetActiveSkyControler()->SetLightDirty();
 			}
 #endif
 			playerLightInt = 500;
-#if ENGINE > Engine_G1
+#if ENGINE >= Engine_G2
 			if (zCSkyControler::GetActiveSkyControler())
 			{
 				zCSkyControler::GetActiveSkyControler()->SetLightDirty();

--- a/SpacerNET_Union/Utils.cpp
+++ b/SpacerNET_Union/Utils.cpp
@@ -28,7 +28,11 @@ namespace GOTHIC_ENGINE {
 
 #if ENGINE == Engine_G1
 	int& playerLightInt = *(int*)0x0083AB90;
-#else
+#elif ENGINE == Engine_G1A
+	int& playerLightInt = *(int*)0x0088079C;
+#elif ENGINE == Engine_G2
+	int& playerLightInt = *(int*)0x00890970;
+#elif ENGINE == Engine_G2A
 	int& playerLightInt = *(int*)0x0089EBB4;
 #endif
 
@@ -59,24 +63,24 @@ namespace GOTHIC_ENGINE {
 	void ClearLMB()
 	{
 #if ENGINE == Engine_G1
-	//FIXME_G1	addr ClearLMB?
-		int& leftMouseVal = *(int*)0x86CCB8;
-
-		//print.PrintRed(Z leftMouseVal);
-
-		leftMouseVal = 0;
-	
+		*(int*)0x0086CCB8 = 0;
+#elif ENGINE == Engine_G1A
+		* (int*)0x008B27B4 = 0;
+#elif ENGINE == Engine_G2
+		* (int*)0x008C3010 = 0;
 #elif ENGINE == Engine_G2A
-		*(int*)0x8D1668 = 0;
+		*(int*)0x008D1668 = 0;
 #endif
 	}
 
 	void __cdecl PlaySoundGame(class zSTRING &)
 	{
 #if ENGINE == Engine_G1
-		
 		XCALL(0x00641350);
-
+#elif ENGINE == Engine_G1A
+		XCALL(0x006684F0);
+#elif ENGINE == Engine_G2
+		XCALL(0x0066F250);
 #elif ENGINE == Engine_G2A
 		XCALL(0x006CBFD0);
 #endif
@@ -89,9 +93,11 @@ namespace GOTHIC_ENGINE {
 	int GetFPS(void)
 	{
 #if ENGINE == Engine_G1
-
 		XCALL(0x004EF790);
-
+#elif ENGINE == Engine_G1A
+		XCALL(0x00502030);
+#elif ENGINE == Engine_G2
+		XCALL(0x004FB050);
 #elif ENGINE == Engine_G2A
 		XCALL(0x004FDCD0);
 #endif
@@ -102,9 +108,11 @@ namespace GOTHIC_ENGINE {
 	void __cdecl sysEvent()
 	{
 #if ENGINE == Engine_G1
-
 		XCALL(0x004F6AC0);
-		
+#elif ENGINE == Engine_G1A
+		XCALL(0x00509530);
+#elif ENGINE == Engine_G2
+		XCALL(0x005026F0);
 #elif ENGINE == Engine_G2A
 		XCALL(0x005053E0);
 #endif
@@ -383,7 +391,7 @@ namespace GOTHIC_ENGINE {
 
 		delete fileListWork;
 
-		//MessageBox(0, zSTRING("Ñïèñîê ñîçäàí!").ToChar(), 0, 0);
+		//MessageBox(0, zSTRING("ÅƒÄÄÅ„Ã®Ä™ Å„Ã®Ã§Ã¤Å•Ã­!").ToChar(), 0, 0);
 	}
 
 
@@ -1228,7 +1236,7 @@ namespace GOTHIC_ENGINE {
 
 				//FIXME_G1 SUPPORT GetMesh
 #else
-				// ïûòàåìñÿ ïðåîáðàçîâàòü âèçóàë â "ïðîã ìåø ïðîòî"
+				// ÄÅ±ÅˆÅ•ÄºÄ›Å„Ë™ ÄÄ‘ÄºÃ®Ã¡Ä‘Å•Ã§Ã®Ã¢Å•ÅˆÃ¼ Ã¢ÄÃ§Ã³Å•Ã« Ã¢ "ÄÄ‘Ã®Äƒ Ä›ÄºÅ™ ÄÄ‘Ã®ÅˆÃ®"
 				zCProgMeshProto* pProgMeshChild = vobChild->visual->CastTo<zCProgMeshProto>();
 				if (pProgMeshChild)
 				{
@@ -1277,7 +1285,7 @@ namespace GOTHIC_ENGINE {
 		return;
 #else
 
-		// ïûòàåìñÿ ïðåîáðàçîâàòü âèçóàë â "ïðîã ìåø ïðîòî"
+		// ÄÅ±ÅˆÅ•ÄºÄ›Å„Ë™ ÄÄ‘ÄºÃ®Ã¡Ä‘Å•Ã§Ã®Ã¢Å•ÅˆÃ¼ Ã¢ÄÃ§Ã³Å•Ã« Ã¢ "ÄÄ‘Ã®Äƒ Ä›ÄºÅ™ ÄÄ‘Ã®ÅˆÃ®"
 		zCProgMeshProto* pProgMesh = pVob->visual->CastTo<zCProgMeshProto>();
 
 		if (!pProgMesh)
@@ -1320,7 +1328,7 @@ namespace GOTHIC_ENGINE {
 
 		fileName.Replace(".3DS", ".MSH");
 
-		if (!fileName.contains(".MSH"))
+		if (!fileName.Contains(".MSH"))
 		{
 			fileName = fileName + ".MSH";
 		}
@@ -1436,7 +1444,7 @@ namespace GOTHIC_ENGINE {
 		CString cstr = str;
 		zCArray<zSTRING> carr;
 		Array<CStringA> arr = cstr.Split(t);
-		for (int i = 0; i < arr.GetNum(); i++) {
+		for (uint i = 0; i < arr.GetNum(); i++) {
 			CStringA* node = arr.GetSafe(i);
 			if (node) {
 				zSTRING snode = *node;

--- a/SpacerNET_Union/Utils.h
+++ b/SpacerNET_Union/Utils.h
@@ -1,10 +1,17 @@
-template<typename Key, typename Value>
-void DeleteAndClearMap(Common::Map<Key, Value*>& map)
-{
-	for (auto& pointer : map)
-	{
-		pointer.Delete();
-	}
+// Supported with union (c) 2020 Union team
+// Union HEADER file
 
-	map.Clear();
+namespace GOTHIC_ENGINE {
+	// Add your code here . . .
+
+	template<typename Key, typename Value>
+	void DeleteAndClearMap(Common::Map<Key, Value*>& map)
+	{
+		for (auto& pointer : map)
+		{
+			pointer.Delete();
+		}
+
+		map.Clear();
+	}
 }

--- a/SpacerNET_Union/Vob.cpp
+++ b/SpacerNET_Union/Vob.cpp
@@ -219,7 +219,7 @@ namespace GOTHIC_ENGINE {
 				if (auto pVob = theApp.GetSelectedVob())
 				{
 
-					if (!theApp.floorVob->GetVisual() || !theApp.floorVob->GetVisual()->objectName.contains(".TGA"))
+					if (!theApp.floorVob->GetVisual() || !theApp.floorVob->GetVisual()->objectName.Contains(".TGA"))
 					{
 						floorVob->SetVisual("SPACER_CIRCLE_ITEM.TGA");
 

--- a/SpacerNET_Union/VobManipulator.cpp
+++ b/SpacerNET_Union/VobManipulator.cpp
@@ -665,7 +665,7 @@ namespace GOTHIC_ENGINE {
 
 			if (useHierarchy && (theApp.vobToCopy == theApp.pickedVob || checkCopyVobSelf) && !pItem && !pickedVobWaypont)
 			{
-				//print.PrintRed("Не могу вставить воб самого в себя!");
+				//print.PrintRed("ГЌДє Д›Г®ДѓГі ГўЕ„Е€Е•ГўДЌЕ€Гј ГўГ®ГЎ Е„Е•Д›Г®ДѓГ® Гў Е„ДєГЎЛ™!");
 				//return;
 				useHierarchy = false;
 			}
@@ -860,11 +860,7 @@ namespace GOTHIC_ENGINE {
 			zCPolygon *poly = bspTree.mesh->Poly(i);
 			if (poly->flags.occluder || poly->flags.ghostOccluder) {
 
-#if ENGINE >= Engine_G2
 				poly->SetMaterial(mat);
-#else
-				poly->material = mat;
-#endif
 			};
 		};
 
@@ -876,7 +872,7 @@ namespace GOTHIC_ENGINE {
 
 	zCTexture* GetScreenTex(zSTRING name)
 	{
-		zCTextureConvert* texCon = zrenderer->CreateTextureConvert();
+		zCTexConGeneric* texCon = reinterpret_cast<zCTexConGeneric*>(zrenderer->CreateTextureConvert());
 		zrenderer->Vid_GetFrontBufferCopy(*texCon);
 		zCTextureInfo texInfo = texCon->GetTextureInfo();
 
@@ -1175,7 +1171,7 @@ namespace GOTHIC_ENGINE {
 					}
 
 					cmd << pEntry->name << ", [" << pEntry->countLoc << "/" << pEntry->countCont 
-						<< "]. Всего: " << pEntry->amoutLoc << "/"
+						<< "]. Г‚Е„ДєДѓГ®: " << pEntry->amoutLoc << "/"
 						<< pEntry->amountCont
 						<< " (" << pEntry->amountAll << ")"
 						<< endl;
@@ -1487,7 +1483,7 @@ namespace GOTHIC_ENGINE {
 				{
 					mm.CopyTextureName();
 					//mm.copyMat = mm.selPolyList->Get(0)->GetPolygon()->material;
-					//print.PrintRed("Материал скопирован");
+					//print.PrintRed("ДљЕ•Е€ДєД‘ДЌЕ•Г« Е„Д™Г®ДЏДЌД‘Г®ГўЕ•Г­");
 				}
 
 			}

--- a/SpacerNET_Union/World.cpp
+++ b/SpacerNET_Union/World.cpp
@@ -37,11 +37,6 @@ namespace GOTHIC_ENGINE {
 	
 	*/
 
-	
-	
-
-
-	#define MAXSIZE 24
 	#define d(i) (((char *)data)+(i)*size)
 
 
@@ -55,6 +50,7 @@ namespace GOTHIC_ENGINE {
 	
 
 	void insertionsort(void *data, size_t num, size_t size, int(__cdecl *compare)(const void *, const void *), bool falltoqs) {
+		constexpr int MAXSIZE = 24;
 		char swapplace[MAXSIZE];
 
 		OutFile("Sort: num: " + ToStr (int)num + " size: " + ToStr(int)size, true);
@@ -610,7 +606,7 @@ namespace GOTHIC_ENGINE {
 
 		oCNpc::SetNpcAIDisabled(TRUE);
 		dynamic_cast<oCGame*>(gameMan->gameSession)->GetSpawnManager()->SetSpawningEnabled(FALSE);
-#if ENGINE > Engine_G1
+#if ENGINE >= Engine_G2
 		zCWorld::s_bAlternateRenderOrder = false;
 #endif
 		ogame->CamInit();
@@ -638,12 +634,16 @@ namespace GOTHIC_ENGINE {
 		//ogame->InsertObjectRoutine(0, "FIREPLACE", 7, 0, 0);
 
 		levelReady = false;
+
+		// kill gLogStatistics
 #if ENGINE == Engine_G1
-		// kill gLogStatistics
-		*(int*)0x0085EB00 = 0;
-#else
-		// kill gLogStatistics
-		* (int*)0x008C2B50 = 0;
+		*(bool*)0x0085EB00 = false;
+#elif ENGINE == Engine_G1A
+		*(bool*)0x008A3454 = false;
+#elif ENGINE == Engine_G2
+		*(bool*)0x008B4590 = false;
+#elif ENGINE == Engine_G2A
+		*(bool*)0x008C2B50 = false;
 #endif
 
 
@@ -742,7 +742,7 @@ namespace GOTHIC_ENGINE {
 			{
 				SetTime(12, 0);
 				zCTexture::RefreshTexMaxSize(16384);
-#if ENGINE > Engine_G1
+#if ENGINE >= Engine_G2
 				zCSkyControler::s_activeSkyControler->m_fRelightTime = 0;
 #endif
 				SetRangeVobs();
@@ -751,7 +751,7 @@ namespace GOTHIC_ENGINE {
 
 			//zCBspTree::s_renderAllPortals = TRUE;
 			//zCBspTree::s_showPortals = TRUE;
-#if ENGINE > Engine_G1
+#if ENGINE >= Engine_G2
 			ogame->GetWorld()->SetWaveAnisEnabled(FALSE);
 
 

--- a/SpacerNET_Union/ZenGin/Gothic_II_Addon/API/zString.h
+++ b/SpacerNET_Union/ZenGin/Gothic_II_Addon/API/zString.h
@@ -115,10 +115,6 @@ namespace Gothic_II_Addon {
     int Search( char const*, unsigned int ) const                                 zCall( 0x0059D110 );
     void Init()                                                                   zCall( 0x006D9B80 );
 
-	INLINE bool_t Contains(const zSTRING& cmp) const {
-		return this->HasWord(cmp);
-	}
-
   public:
 #if USING_UNION_STRING_METHODS
 
@@ -189,7 +185,7 @@ namespace Gothic_II_Addon {
       return ((CStringA&)*this).CompareMaskedI( (CStringA&)str );
     }
 
-	INLINE bool_t contains(const zSTRING& cmp) const {
+	INLINE bool_t Contains(const zSTRING& cmp) const {
 		return this->HasWord(cmp);
 	}
 

--- a/SpacerNET_Union/ZenGin/Gothic_II_Classic/API/zContainer.h
+++ b/SpacerNET_Union/ZenGin/Gothic_II_Classic/API/zContainer.h
@@ -278,7 +278,6 @@ namespace Gothic_II_Classic {
           }
         }
       }
-      return False;
     }
 
     void DeleteListDatas() {
@@ -448,6 +447,18 @@ namespace Gothic_II_Classic {
       memmove( &array[pos + 1], &array[pos], sizeof( T ) * ( numInArray - pos ) );
       array[pos] = ins;
       numInArray++;
+    }
+
+    void RemoveDoubles() {
+      for (int i = 0; i < GetNumInList() - 1; i++) {
+        for (int j = i + 1; j < GetNumInList(); j++) {
+          if (array[i] == array[j]) {
+            array[j] = array[numInArray - 1];
+            numInArray--;
+            j--;
+          }
+        }
+      }
     }
 
     void InsertSort( const T& ins ) {

--- a/SpacerNET_Union/ZenGin/Gothic_II_Classic/API/zString.h
+++ b/SpacerNET_Union/ZenGin/Gothic_II_Classic/API/zString.h
@@ -4,7 +4,7 @@
 #define __ZSTRING_H__VER2__
 
 #define USING_UNION_STRING_METHODS True
-#define UNPROTECT_ZSTRING_METHODS  False
+#define UNPROTECT_ZSTRING_METHODS  True
 
 namespace Gothic_II_Classic {
   inline void CreateDirectories( CStringA path ) {
@@ -182,6 +182,10 @@ namespace Gothic_II_Classic {
 
     INLINE bool_t CompareMaskedI( const CStringA& str ) const {
       return ((CStringA&)*this).CompareMaskedI( (CStringA&)str );
+    }
+
+    INLINE bool_t Contains(const zSTRING& cmp) const {
+        return this->HasWord(cmp);
     }
 
     INLINE bool_t HasWord( const zSTRING& cmp ) const {

--- a/SpacerNET_Union/ZenGin/Gothic_II_Classic/API/zVertexTransform.h
+++ b/SpacerNET_Union/ZenGin/Gothic_II_Classic/API/zVertexTransform.h
@@ -20,6 +20,8 @@ namespace Gothic_II_Classic {
 
     // user API
     #include "zCVertexTransform.inl"
+
+    static zCVolatileMemoryBase& s_MemMan;
   };
 
 } // namespace Gothic_II_Classic

--- a/SpacerNET_Union/ZenGin/Gothic_II_Classic/Statics_G2.cpp
+++ b/SpacerNET_Union/ZenGin/Gothic_II_Classic/Statics_G2.cpp
@@ -562,4 +562,8 @@ namespace Gothic_II_Classic {
   zCCollisionObjectDef* zCCollObjectProjectile::s_oCollObjClass     = (zCCollisionObjectDef*)0x008C9CE8;
 #endif // __ZCOLLISION_OBJECT_MISC_H__VER2__
 
+#ifdef __ZVERTEX_TRANSFORM_H__VER2__
+  zCVolatileMemoryBase& zCVertexTransform::s_MemMan = *(zCVolatileMemoryBase*)0x008C5CE8;
+#endif
+
 } // namespace Gothic_II_Classic

--- a/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zAlgebra.h
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zAlgebra.h
@@ -259,6 +259,31 @@ namespace Gothic_I_Addon {
       n[2] = a0[2];
     }
 
+    float LengthApprox() const {
+        float ix = n[VX];
+        float iy = n[VY];
+        float iz = n[VZ];
+
+        if (ix < 0.0f) ix *= -1.0;
+        if (iy < 0.0f) iy *= -1.0;
+        if (iz < 0.0f) iz *= -1.0;
+
+        if (ix < iy) {
+            float it = ix;
+            ix = iy;
+            iy = it;
+        }
+
+        if (ix < iz) {
+            float it = ix;
+            ix = iz;
+            iz = it;
+        }
+
+        float t = iy + iz;
+        return ix - (ix * (1.0f / 16.0f)) + (t * (1.0f / 4.0f)) + (t * (1.0f / 8.0f));
+    }
+
     float Length() const
     {
       return sqrt( Length_Sqr() );

--- a/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zContainer.h
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zContainer.h
@@ -281,7 +281,6 @@ namespace Gothic_I_Addon {
           }
         }
       }
-      return False;
     }
 
     void DeleteListDatas() {
@@ -451,6 +450,18 @@ namespace Gothic_I_Addon {
       memmove( &array[pos + 1], &array[pos], sizeof( T ) * ( numInArray - pos ) );
       array[pos] = ins;
       numInArray++;
+    }
+
+    void RemoveDoubles() {
+      for (int i = 0; i < GetNumInList() - 1; i++) {
+        for (int j = i + 1; j < GetNumInList(); j++) {
+          if (array[i] == array[j]) {
+            array[j] = array[numInArray - 1];
+            numInArray--;
+            j--;
+          }
+        }
+      }
     }
 
     void InsertSort( const T& ins ) {
@@ -1231,6 +1242,7 @@ namespace Gothic_I_Addon {
 
   template <class T>
   class zCList {
+  public:
     T *data;
     zCList *next;
   public:

--- a/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zString.h
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zString.h
@@ -4,7 +4,7 @@
 #define __ZSTRING_H__VER1__
 
 #define USING_UNION_STRING_METHODS True
-#define UNPROTECT_ZSTRING_METHODS  False
+#define UNPROTECT_ZSTRING_METHODS  True
 
 namespace Gothic_I_Addon {
 
@@ -183,6 +183,10 @@ namespace Gothic_I_Addon {
 
     INLINE bool_t CompareMaskedI( const CStringA& str ) const {
       return ((CStringA&)*this).CompareMaskedI( (CStringA&)str );
+    }
+
+    INLINE bool_t Contains(const zSTRING& cmp) const {
+        return this->HasWord(cmp);
     }
 
     INLINE bool_t HasWord( const zSTRING& cmp ) const {

--- a/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zVertexTransform.h
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Addon/API/zVertexTransform.h
@@ -20,6 +20,8 @@ namespace Gothic_I_Addon {
 
     // user API
     #include "zCVertexTransform.inl"
+
+    static zCVolatileMemoryBase& s_MemMan;
   };
 
 } // namespace Gothic_I_Addon

--- a/SpacerNET_Union/ZenGin/Gothic_I_Addon/Statics_G1A.cpp
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Addon/Statics_G1A.cpp
@@ -520,5 +520,8 @@ namespace Gothic_I_Addon {
   zCCollisionObjectDef* zCCollObjectProjectile::s_oCollObjClass     = (zCCollisionObjectDef*)0x008B9288;
 #endif // __ZCOLLISION_OBJECT_MISC_H__VER1__
 
+#ifdef __ZVERTEX_TRANSFORM_H__VER1__
+  zCVolatileMemoryBase& zCVertexTransform::s_MemMan = *(zCVolatileMemoryBase*)0x008B51F0;
+#endif
 
 } // namespace Gothic_I_Addon

--- a/SpacerNET_Union/ZenGin/Gothic_I_Classic/API/zContainer.h
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Classic/API/zContainer.h
@@ -281,7 +281,6 @@ namespace Gothic_I_Classic {
           }
         }
       }
-      return;
     }
 
     void DeleteListDatas() {
@@ -433,7 +432,6 @@ namespace Gothic_I_Classic {
                 }
             }
         }
-        return;
     }
 
     void InsertEnd( const T& ins ) {

--- a/SpacerNET_Union/ZenGin/Gothic_I_Classic/API/zString.h
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Classic/API/zString.h
@@ -114,10 +114,7 @@ namespace Gothic_I_Classic {
     float ToFloat() const                                                         zCall( 0x0057E310 );
     int Search( char const*, unsigned int ) const                                 zCall( 0x0057E330 );
     void Init()                                                                   zCall( 0x00737C50 );
-    
-    INLINE bool_t Contains(const zSTRING& cmp) const {
-        return this->HasWord(cmp);
-    }
+
   public:
 #if USING_UNION_STRING_METHODS
 
@@ -188,13 +185,14 @@ namespace Gothic_I_Classic {
       return ((CStringA&)*this).CompareMaskedI( (CStringA&)str );
     }
 
+    INLINE bool_t Contains(const zSTRING& cmp) const {
+        return this->HasWord(cmp);
+    }
+
     INLINE bool_t HasWord( const zSTRING& cmp ) const {
       return ((CStringA&)*this).HasWord( cmp );
     }
 
-    INLINE bool_t contains(const zSTRING& cmp) const {
-        return this->HasWord(cmp);
-    }
 
     // case Insensitive
     INLINE bool_t HasWordI( const zSTRING& cmp ) const {

--- a/SpacerNET_Union/ZenGin/Gothic_I_Classic/API/zVertexTransform.h
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Classic/API/zVertexTransform.h
@@ -20,6 +20,8 @@ namespace Gothic_I_Classic {
 
     // user API
     #include "zCVertexTransform.inl"
+
+    static zCVolatileMemoryBase& s_MemMan;
   };
 
 } // namespace Gothic_I_Classic

--- a/SpacerNET_Union/ZenGin/Gothic_I_Classic/Statics_G1.cpp
+++ b/SpacerNET_Union/ZenGin/Gothic_I_Classic/Statics_G1.cpp
@@ -521,4 +521,8 @@ namespace Gothic_I_Classic {
   zCCollisionObjectDef* zCCollObjectProjectile::s_oCollObjClass     = (zCCollisionObjectDef*)0x008735D4;
 #endif // __ZCOLLISION_OBJECT_MISC_H__VER0__
 
+#ifdef __ZVERTEX_TRANSFORM_H__VER0__
+  zCVolatileMemoryBase& zCVertexTransform::s_MemMan = *(zCVolatileMemoryBase*)0x0086F5A8;
+#endif
+
 } // namespace Gothic_I_Classic

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/oCWorldTimer.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/oCWorldTimer.inl
@@ -3,3 +3,4 @@
 // User API for oCWorldTimer
 // Add your methods here
 
+void Timer_Hook();

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCBspTree.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCBspTree.inl
@@ -4,3 +4,4 @@
 // Add your methods here
 
 void AddVob_Hook(zCVob* vob);
+void RenderVobList_Hook();

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCCSCamera.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCCSCamera.inl
@@ -5,7 +5,7 @@
 
 
 void Unarchive_Hook(zCArchiver &);
-zCVob* GetPlayerVob_Hook(zCVob* vob);
+static zCVob* GetPlayerVob_Hook();
 
 int				SearchCamKey(zCCamTrj_KeyFrame*key) { return posKeys.Search(key); };
 int				SearchTargetKey(zCCamTrj_KeyFrame*key) { return targetKeys.Search(key); };

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCCamera.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCCamera.inl
@@ -7,4 +7,11 @@
 void SetVob(zCVob*);
 zCVob* GetVob();
 zVEC3 Transform(const zVEC3& point);
+
+#if ENGINE != Engine_G1A
 inline void BackProject(const int xscr, const int yscr, zVEC3& p) const;
+#endif
+
+#if ENGINE <= Engine_G1A
+inline void ProjectClamp(zCVertexTransform* vertex, const float inv) const;
+#endif

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCPolygon.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCPolygon.inl
@@ -20,6 +20,11 @@ void			__fastcall			SetVertexPtr(zCVertex& vert, int index)
 }
 
 zCMaterial* GetMaterial() const { return material; };
+
+#if ENGINE == Engine_G1
+void SetMaterial(zCMaterial* mat);
+#endif
+
 zCLightMap* GetLightmap() const { return lightmap; };
 zBOOL			GetPortal() const { return flags.portalPoly != zPORTAL_TYPE_NONE; };
 zBOOL			GetSectorFlag() const { return flags.sectorPoly; };

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCTextureConvert.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCTextureConvert.inl
@@ -3,14 +3,4 @@
 // User API for zCTextureConvert
 // Add your methods here
 
-
-#if ENGINE == Engine_G2A
-int ConvertTextureFormat(zCTextureInfo const&) zCall(0x006598E0);
-void SetDetailTextureMode(int) zCall(0x0065B7A0);
-#else
-int ConvertTextureFormat(zCTextureInfo const&) zCall(0x00720DC0);
-void SetDetailTextureMode(int) zCall(0x00722BD0);
-#endif
-
-
 zBOOL zCTextureConvert::SaveToFileFormat_Union(const zSTRING& fileName);

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCVob.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/zCVob.inl
@@ -70,3 +70,4 @@ bool HasChildren()
 	return NULL;
 }
 
+BOOL __fastcall Render_Union(zTRenderContext &renderContext);

--- a/SpacerNET_Union/ZenGin/Gothic_UserAPI/zTBBox3D.inl
+++ b/SpacerNET_Union/ZenGin/Gothic_UserAPI/zTBBox3D.inl
@@ -12,3 +12,7 @@ float GetMaxExtent();
 //zBOOL IsIntersecting(const zPOINT3& rayOrigin, const zVEC3& rayDirection, zREAL& scaleMin, zREAL& scaleMax);
 
 #endif
+
+#if ENGINE < Engine_G2A
+zBOOL IsIntersecting(const zVEC3& rayOrigin, const zVEC3& rayDirection, zREAL& scaleMin, zREAL& scaleMax) const;
+#endif


### PR DESCRIPTION
- Fixed used string methods
- Fixed holding time on different platforms than G2A
- Added missing zCPolygon::SetMaterial method for G1
- Removed useless zCTextureConvert methods from .inl file, and added reinterpret_cast<zCTexConGeneric>(texConv) instead
- Added missing zTBBox3D::IsIntersecting for other engines than G2A
- Disabled defining zCCamera::BackProject for G1A
- Hooked oCWorldTimer::Timer method to manually control whether or not time should be passing for each platform
- Adjusted zSTRING classes for different engines to be compatible with each other
- Removed unnecessary engine specific variables from PFX_Editor.cpp, they can be accessed via zCParser class (as static fields)
- Added missing zVEC3::LengthApprox for G1A
- Added missing zCArraySort::RemoveDoubles methods for other engines
- Merge duplicate code for multiple engines together
- Refactorization and other changes that i don't remember...