### PR TITLE
feat: add auto-save with 10 rotating slots every 5 minutes

### DIFF
--- a/SpacerNET_Union/CSettings.cpp
+++ b/SpacerNET_Union/CSettings.cpp
@@ -664,7 +664,14 @@ namespace GOTHIC_ENGINE {
 
 		set = new CSetting(TYPE_INT, "GRASS", "grassToolSetOnVob", "0");
 		list.Insert("grassToolSetOnVob", set);
-	}	
+
+		// AUTOSAVE
+		set = new CSetting(TYPE_INT, "AUTOSAVE", "checkBoxAutoSave", "0");
+		list.Insert("checkBoxAutoSave", set);
+
+		set = new CSetting(TYPE_INT, "AUTOSAVE", "autoSaveSlot", "0");
+		list.Insert("autoSaveSlot", set);
+	}
 
 	CSettings::~CSettings()
 	{

--- a/SpacerNET_Union/Export.cpp
+++ b/SpacerNET_Union/Export.cpp
@@ -421,6 +421,7 @@ namespace GOTHIC_ENGINE {
 
 			theApp.options.SetIntVal(name, value);
 			theApp.options.Apply();
+			theApp.options.Save();
 
 		}
 

--- a/SpacerNET_Union/Macros.h
+++ b/SpacerNET_Union/Macros.h
@@ -85,6 +85,7 @@ namespace GOTHIC_ENGINE {
 	const uint TIMER_ID_PFX_UPDATE_BBOX = 2;
 	const uint TIMER_ID_CHECK_RAM = 3;
 	const uint TIMER_ID_CHECK_NOSAVE_TIME = 4;
+	const uint TIMER_ID_AUTOSAVE = 5;
 
 #if ENGINE == Engine_G1
 #define zERR_NONE 0

--- a/SpacerNET_Union/MyPrint.cpp
+++ b/SpacerNET_Union/MyPrint.cpp
@@ -101,4 +101,30 @@ namespace GOTHIC_ENGINE {
 		zCOLOR color = zCOLOR(0, 255, 0);
 		PrintWin(text, color, time);
 	}
+
+	int MyPrint::PrintGreenTracked(zSTRING text, int time) {
+		zCOLOR color = zCOLOR(0, 255, 0);
+		PrintWinMessage msg;
+		msg.msg = text;
+		msg.amountMillisec = time * 1000;
+		msg.id = currentId++;
+		msg.color = color;
+		if (arrMsgs.GetNum() < pwMaxMsgs) {
+			arrMsgs.Insert(msg);
+		}
+		else {
+			arrMsgs.RemoveIndex(0);
+			arrMsgs.Insert(msg);
+		}
+		return msg.id;
+	}
+
+	void MyPrint::RemoveById(int id) {
+		for (int i = 0; i < arrMsgs.GetNum(); i++) {
+			if (arrMsgs.GetSafe(i).id == id) {
+				arrMsgs.RemoveIndex(i);
+				return;
+			}
+		}
+	}
 }

--- a/SpacerNET_Union/MyPrint.h
+++ b/SpacerNET_Union/MyPrint.h
@@ -25,5 +25,7 @@ namespace GOTHIC_ENGINE {
 		void ClearMsgs();
 		void PrintRed(zSTRING text, int time = 3);
 		void PrintGreen(zSTRING text, int time = 3);
+		int  PrintGreenTracked(zSTRING text, int time = 3); // returns msg ID for later RemoveById
+		void RemoveById(int id);
 	};
 }

--- a/SpacerNET_Union/SpacerApp.h
+++ b/SpacerNET_Union/SpacerApp.h
@@ -538,6 +538,7 @@ namespace GOTHIC_ENGINE {
 
 		void SetChangesWereMade(bool value);
 		bool GetChangesWereMade();
+		void DoAutoSave();
 	};
 
 }

--- a/SpacerNET_Union/Spacer_Loop.cpp
+++ b/SpacerNET_Union/Spacer_Loop.cpp
@@ -602,8 +602,16 @@ namespace GOTHIC_ENGINE {
 		{
 			CheckRamUsage();
 		}
-		
-		
+
+		if (mainTimer[TIMER_ID_AUTOSAVE].Await(5 * 60 * 1000))
+		{
+			if (options.GetIntVal("checkBoxAutoSave") == 1 && !theApp.g_bIsPlayingGame)
+			{
+				theApp.DoAutoSave();
+			}
+		}
+
+
 		//print.PrintRed(Z(int)player);
 
 		/*if (ogame->GetCamera())

--- a/SpacerNET_Union/World.cpp
+++ b/SpacerNET_Union/World.cpp
@@ -1163,4 +1163,83 @@ namespace GOTHIC_ENGINE {
 		}
 	}
 
+	void SpacerApp::DoAutoSave()
+	{
+		zCWorld* world = ogame->GetWorld();
+		if (!world || !world->IsCompiled())
+			return;
+
+		// Next slot (0-indexed, wrap 0..9)
+		int slot    = options.GetIntVal("autoSaveSlot");
+		int newSlot = (slot + 1) % 10;
+
+		// Timestamp string e.g. "2026-04-12_14-30-00"
+		time_t t = time(nullptr);
+		struct tm lt;
+		localtime_s(&lt, &t);
+		char ts[32];
+		strftime(ts, sizeof(ts), "%Y-%m-%d_%H-%M-%S", &lt);
+
+		// Base world name: "WORLD" from e.g. "WORLD.ZEN"
+		zSTRING wfile = world->m_strlevelName;
+		wfile.Replace(".ZEN", "");
+
+		// Save like a normal save — flat filename in DIR_WORLD, then move to autosave subdir
+		char tempName[MAX_PATH];
+		sprintf_s(tempName, sizeof(tempName),
+			"%s_AS_%02d_%s.ZEN", wfile.ToChar(), newSlot + 1, ts);
+
+		zoptions->ChangeDir(DIR_WORLD);
+		HandleWorldBeforeSave();
+
+		// Temporarily save — reuse the engine's proven save path
+		nograss.PrepareObjectsSaveGame();
+		ogame->SaveWorld(zSTRING(tempName), zCWorld::zWLD_SAVE_EDITOR_COMPILED, false, false);
+		nograss.RestoreObjectsSaveGame();
+
+		HandleWorldAfterSave();
+
+		// Now move the file into autosave subdir using Win32 API
+		char worldsDirAbs[MAX_PATH] = {};
+		GetCurrentDirectoryA(MAX_PATH, worldsDirAbs);
+
+		char autosaveDir[MAX_PATH];
+		sprintf_s(autosaveDir, sizeof(autosaveDir), "%s\\autosave", worldsDirAbs);
+		CreateDirectoryA(autosaveDir, NULL);
+
+		// Delete previous file in this slot
+		char oldPattern[MAX_PATH];
+		sprintf_s(oldPattern, sizeof(oldPattern),
+			"%s\\%s_AS_%02d_*.ZEN", autosaveDir, wfile.ToChar(), newSlot + 1);
+
+		WIN32_FIND_DATAA fd;
+		HANDLE hFind = FindFirstFileA(oldPattern, &fd);
+		if (hFind != INVALID_HANDLE_VALUE)
+		{
+			do {
+				char oldPath[MAX_PATH];
+				sprintf_s(oldPath, sizeof(oldPath), "%s\\%s", autosaveDir, fd.cFileName);
+				DeleteFileA(oldPath);
+			} while (FindNextFileA(hFind, &fd));
+			FindClose(hFind);
+		}
+
+		// Move temp file → autosave dir
+		char srcPath[MAX_PATH], dstPath[MAX_PATH];
+		sprintf_s(srcPath, sizeof(srcPath), "%s\\%s", worldsDirAbs, tempName);
+		sprintf_s(dstPath, sizeof(dstPath), "%s\\%s", autosaveDir, tempName);
+
+		MoveFileA(srcPath, dstPath);
+
+		// Persist updated slot index
+		options.SetIntVal("autoSaveSlot", newSlot);
+		options.Save();
+
+		// On-screen confirmation — replace previous autosave msg, show for 30s
+		static int s_lastAutoSaveMsgId = -1;
+		print.RemoveById(s_lastAutoSaveMsgId);
+		CString msg = CString("AutoSave ") + CString(newSlot + 1) + CString(": ") + CString(ts);
+		s_lastAutoSaveMsgId = print.PrintGreenTracked(msg, 30);
+	}
+
 }


### PR DESCRIPTION
Saves the world every 5 minutes into a `autosave/` subdirectory inside the worlds folder with 10 rotating slots and timestamps. Enabled via checkbox in Misc Settings.

- DoAutoSave(): saves via engine's proven SaveWorld path, then moves the file into autosave/ subdir using Win32 MoveFileA
- PrintGreenTracked()/RemoveById(): on-screen confirmation that replaces the previous message instead of stacking
- Extern_SetSetting: now also calls Save() so settings persist across sessions
- TIMER_ID_AUTOSAVE timer constant
- checkBoxAutoSave + autoSaveSlot settings in CSettings