### PR TITLE
Register showStatusBar setting (companion to Interface PR #25)

### DIFF
--- a/SpacerNET_Union/CSettings.cpp
+++ b/SpacerNET_Union/CSettings.cpp
@@ -682,6 +682,8 @@ namespace GOTHIC_ENGINE {
 		set = new CSetting(TYPE_INT, "AUTOSAVE", "autoSaveZenTime", "5");
 		list.Insert("autoSaveZenTime", set);
 
+		set = new CSetting(TYPE_INT, "SPACER", "showStatusBar", "1");
+		list.Insert("showStatusBar", set);
 
 	}
 


### PR DESCRIPTION
## Summary

Registers a new int setting `showStatusBar` (default `1`) in the `SPACER` section so the C# side can persist the visibility of its status bar across restarts via `Extern_GetSetting` / `Extern_SetSetting`.

Companion to [SpacerNET_Interface PR #25](https://github.com/postm1/SpacerNET_Interface/pull/25). Without this registration, the new "Show status bar" checkbox in Misc Settings would always read `0` on load because `CSettings::SetIntVal` silently ignores unknown keys.

## Change

One entry added to `CSettings::Init` next to the existing AUTOSAVE block:

```cpp
set = new CSetting(TYPE_INT, "SPACER", "showStatusBar", "1");
list.Insert("showStatusBar", set);
```

## Test plan

- [x] `build.ps1` clean (G2A Release, x86, ExitCode 0, only pre-existing warnings)
- [ ] After merge + C# PR #25 merge: toggle the checkbox in Misc Settings, restart Spacer, verify state persists in the INI under `[SPACER] showStatusBar=`